### PR TITLE
Add python script to update E2E runs badge

### DIFF
--- a/Openshift-EE/utils/badges/e2eruns_update.py
+++ b/Openshift-EE/utils/badges/e2eruns_update.py
@@ -1,0 +1,30 @@
+import github
+import re
+import sys
+
+
+token = sys.argv[2]
+git_auth = github.Github(token)
+
+repo = git_auth.get_repo("mayadata-io/automation")
+file = repo.get_file_contents("README.md")
+file_content=str(file.decoded_content)
+
+updated_url = ''
+
+if "E2E%20runs" in file_content:
+	url = int(re.findall(r'runs-(.*)-orange',file_content)[0])
+	print(url)
+	num_tests = str(int(sys.argv[1]) + url)
+	num_tests = 'runs-' + num_tests + '-orange'
+	updated_url = re.sub(r'runs-(.*)-orange',num_tests,file_content)
+	updated_url = re.sub(r'\\n','\\n',updated_url)		
+	updated_url = updated_url.strip("b\'\'")
+		
+
+# update,
+repo.update_file("README.md", "E2E runs update", updated_url, file.sha)
+
+
+
+


### PR DESCRIPTION
- Add python script to update E2E runs badge
 - This Python script takes 2 arguments and adds the new_test_run_count with the one already updated in 
 the E2E runs badge placed in mayadata-io/automation repo.
 - python3 e2eruns_update.py <new_test_run_count> <auth_token>



@dargasudarshan @gprasath 